### PR TITLE
Add prototype for translating UMLS IDs to QIDs

### DIFF
--- a/wikidata_umls_linking/LICENSE
+++ b/wikidata_umls_linking/LICENSE
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2020, jvfe
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/wikidata_umls_linking/README.md
+++ b/wikidata_umls_linking/README.md
@@ -1,0 +1,9 @@
+# wdt_linking
+
+Just playing around with SciSpacy and wikidataintegrator while waiting for stuff to download.
+
+It's a very rough prototype to translate UMLS IDs identified by scispacy to Wikidata QIDs.
+
+Made to be ran inside of colab, cause it takes a lot of RAM (>7GB)
+So click here:
+<a href="https://colab.research.google.com/github/jvfe/wdt_contribs/blob/master/wdt_scispacy_linking_prototype.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>

--- a/wikidata_umls_linking/src/wdt_scispacy_linking_prototype.ipynb
+++ b/wikidata_umls_linking/src/wdt_scispacy_linking_prototype.ipynb
@@ -1,0 +1,462 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "wdt_scispacy_linking_prototype.ipynb",
+      "provenance": [],
+      "collapsed_sections": [],
+      "authorship_tag": "ABX9TyPjFAjcCDCoxaxlb7ZmQGTf",
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/jvfe/wdt_contribs/blob/master/wdt_scispacy_linking_prototype.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "v0hVqAJ-nKzF",
+        "colab_type": "text"
+      },
+      "source": [
+        "#### Enviroment setup\n",
+        "\n",
+        "Downloading models and defining functions, this takes a while."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "G_no39qRZzRi",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "outputId": "5f7716db-cb77-4279-9147-9ce0032f4956"
+      },
+      "source": [
+        "!pip install scispacy\n",
+        "!pip install https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.5/en_core_sci_md-0.2.5.tar.gz # Medium sized language model\n",
+        "!pip install wikidataintegrator"
+      ],
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Requirement already satisfied: scispacy in /usr/local/lib/python3.6/dist-packages (0.2.5)\n",
+            "Requirement already satisfied: scikit-learn>=0.20.3 in /usr/local/lib/python3.6/dist-packages (from scispacy) (0.22.2.post1)\n",
+            "Requirement already satisfied: requests<3.0.0conllu,>=2.0.0 in /usr/local/lib/python3.6/dist-packages (from scispacy) (2.23.0)\n",
+            "Requirement already satisfied: nmslib>=1.7.3.6 in /usr/local/lib/python3.6/dist-packages (from scispacy) (2.0.6)\n",
+            "Requirement already satisfied: spacy<3.0.0,>=2.3.0 in /usr/local/lib/python3.6/dist-packages (from scispacy) (2.3.2)\n",
+            "Requirement already satisfied: joblib in /usr/local/lib/python3.6/dist-packages (from scispacy) (0.16.0)\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.6/dist-packages (from scispacy) (1.18.5)\n",
+            "Requirement already satisfied: pysbd in /usr/local/lib/python3.6/dist-packages (from scispacy) (0.3.1)\n",
+            "Requirement already satisfied: scipy>=0.17.0 in /usr/local/lib/python3.6/dist-packages (from scikit-learn>=0.20.3->scispacy) (1.4.1)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.6/dist-packages (from requests<3.0.0conllu,>=2.0.0->scispacy) (2020.6.20)\n",
+            "Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.6/dist-packages (from requests<3.0.0conllu,>=2.0.0->scispacy) (3.0.4)\n",
+            "Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.6/dist-packages (from requests<3.0.0conllu,>=2.0.0->scispacy) (2.10)\n",
+            "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.6/dist-packages (from requests<3.0.0conllu,>=2.0.0->scispacy) (1.24.3)\n",
+            "Requirement already satisfied: pybind11>=2.2.3 in /usr/local/lib/python3.6/dist-packages (from nmslib>=1.7.3.6->scispacy) (2.5.0)\n",
+            "Requirement already satisfied: psutil in /usr/local/lib/python3.6/dist-packages (from nmslib>=1.7.3.6->scispacy) (5.4.8)\n",
+            "Requirement already satisfied: murmurhash<1.1.0,>=0.28.0 in /usr/local/lib/python3.6/dist-packages (from spacy<3.0.0,>=2.3.0->scispacy) (1.0.2)\n",
+            "Requirement already satisfied: thinc==7.4.1 in /usr/local/lib/python3.6/dist-packages (from spacy<3.0.0,>=2.3.0->scispacy) (7.4.1)\n",
+            "Requirement already satisfied: tqdm<5.0.0,>=4.38.0 in /usr/local/lib/python3.6/dist-packages (from spacy<3.0.0,>=2.3.0->scispacy) (4.41.1)\n",
+            "Requirement already satisfied: cymem<2.1.0,>=2.0.2 in /usr/local/lib/python3.6/dist-packages (from spacy<3.0.0,>=2.3.0->scispacy) (2.0.3)\n",
+            "Requirement already satisfied: blis<0.5.0,>=0.4.0 in /usr/local/lib/python3.6/dist-packages (from spacy<3.0.0,>=2.3.0->scispacy) (0.4.1)\n",
+            "Requirement already satisfied: plac<1.2.0,>=0.9.6 in /usr/local/lib/python3.6/dist-packages (from spacy<3.0.0,>=2.3.0->scispacy) (1.1.3)\n",
+            "Requirement already satisfied: setuptools in /usr/local/lib/python3.6/dist-packages (from spacy<3.0.0,>=2.3.0->scispacy) (49.6.0)\n",
+            "Requirement already satisfied: srsly<1.1.0,>=1.0.2 in /usr/local/lib/python3.6/dist-packages (from spacy<3.0.0,>=2.3.0->scispacy) (1.0.2)\n",
+            "Requirement already satisfied: preshed<3.1.0,>=3.0.2 in /usr/local/lib/python3.6/dist-packages (from spacy<3.0.0,>=2.3.0->scispacy) (3.0.2)\n",
+            "Requirement already satisfied: catalogue<1.1.0,>=0.0.7 in /usr/local/lib/python3.6/dist-packages (from spacy<3.0.0,>=2.3.0->scispacy) (1.0.0)\n",
+            "Requirement already satisfied: wasabi<1.1.0,>=0.4.0 in /usr/local/lib/python3.6/dist-packages (from spacy<3.0.0,>=2.3.0->scispacy) (0.7.1)\n",
+            "Requirement already satisfied: importlib-metadata>=0.20; python_version < \"3.8\" in /usr/local/lib/python3.6/dist-packages (from catalogue<1.1.0,>=0.0.7->spacy<3.0.0,>=2.3.0->scispacy) (1.7.0)\n",
+            "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.6/dist-packages (from importlib-metadata>=0.20; python_version < \"3.8\"->catalogue<1.1.0,>=0.0.7->spacy<3.0.0,>=2.3.0->scispacy) (3.1.0)\n",
+            "Collecting https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.5/en_core_sci_md-0.2.5.tar.gz\n",
+            "  Using cached https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.5/en_core_sci_md-0.2.5.tar.gz\n",
+            "Requirement already satisfied (use --upgrade to upgrade): en-core-sci-md==0.2.5 from https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.5/en_core_sci_md-0.2.5.tar.gz in /usr/local/lib/python3.6/dist-packages\n",
+            "Requirement already satisfied: spacy>=2.3.0 in /usr/local/lib/python3.6/dist-packages (from en-core-sci-md==0.2.5) (2.3.2)\n",
+            "Requirement already satisfied: requests<3.0.0,>=2.13.0 in /usr/local/lib/python3.6/dist-packages (from spacy>=2.3.0->en-core-sci-md==0.2.5) (2.23.0)\n",
+            "Requirement already satisfied: srsly<1.1.0,>=1.0.2 in /usr/local/lib/python3.6/dist-packages (from spacy>=2.3.0->en-core-sci-md==0.2.5) (1.0.2)\n",
+            "Requirement already satisfied: murmurhash<1.1.0,>=0.28.0 in /usr/local/lib/python3.6/dist-packages (from spacy>=2.3.0->en-core-sci-md==0.2.5) (1.0.2)\n",
+            "Requirement already satisfied: wasabi<1.1.0,>=0.4.0 in /usr/local/lib/python3.6/dist-packages (from spacy>=2.3.0->en-core-sci-md==0.2.5) (0.7.1)\n",
+            "Requirement already satisfied: catalogue<1.1.0,>=0.0.7 in /usr/local/lib/python3.6/dist-packages (from spacy>=2.3.0->en-core-sci-md==0.2.5) (1.0.0)\n",
+            "Requirement already satisfied: thinc==7.4.1 in /usr/local/lib/python3.6/dist-packages (from spacy>=2.3.0->en-core-sci-md==0.2.5) (7.4.1)\n",
+            "Requirement already satisfied: blis<0.5.0,>=0.4.0 in /usr/local/lib/python3.6/dist-packages (from spacy>=2.3.0->en-core-sci-md==0.2.5) (0.4.1)\n",
+            "Requirement already satisfied: setuptools in /usr/local/lib/python3.6/dist-packages (from spacy>=2.3.0->en-core-sci-md==0.2.5) (49.6.0)\n",
+            "Requirement already satisfied: cymem<2.1.0,>=2.0.2 in /usr/local/lib/python3.6/dist-packages (from spacy>=2.3.0->en-core-sci-md==0.2.5) (2.0.3)\n",
+            "Requirement already satisfied: tqdm<5.0.0,>=4.38.0 in /usr/local/lib/python3.6/dist-packages (from spacy>=2.3.0->en-core-sci-md==0.2.5) (4.41.1)\n",
+            "Requirement already satisfied: preshed<3.1.0,>=3.0.2 in /usr/local/lib/python3.6/dist-packages (from spacy>=2.3.0->en-core-sci-md==0.2.5) (3.0.2)\n",
+            "Requirement already satisfied: plac<1.2.0,>=0.9.6 in /usr/local/lib/python3.6/dist-packages (from spacy>=2.3.0->en-core-sci-md==0.2.5) (1.1.3)\n",
+            "Requirement already satisfied: numpy>=1.15.0 in /usr/local/lib/python3.6/dist-packages (from spacy>=2.3.0->en-core-sci-md==0.2.5) (1.18.5)\n",
+            "Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.6/dist-packages (from requests<3.0.0,>=2.13.0->spacy>=2.3.0->en-core-sci-md==0.2.5) (2.10)\n",
+            "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.6/dist-packages (from requests<3.0.0,>=2.13.0->spacy>=2.3.0->en-core-sci-md==0.2.5) (1.24.3)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.6/dist-packages (from requests<3.0.0,>=2.13.0->spacy>=2.3.0->en-core-sci-md==0.2.5) (2020.6.20)\n",
+            "Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.6/dist-packages (from requests<3.0.0,>=2.13.0->spacy>=2.3.0->en-core-sci-md==0.2.5) (3.0.4)\n",
+            "Requirement already satisfied: importlib-metadata>=0.20; python_version < \"3.8\" in /usr/local/lib/python3.6/dist-packages (from catalogue<1.1.0,>=0.0.7->spacy>=2.3.0->en-core-sci-md==0.2.5) (1.7.0)\n",
+            "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.6/dist-packages (from importlib-metadata>=0.20; python_version < \"3.8\"->catalogue<1.1.0,>=0.0.7->spacy>=2.3.0->en-core-sci-md==0.2.5) (3.1.0)\n",
+            "Building wheels for collected packages: en-core-sci-md\n",
+            "  Building wheel for en-core-sci-md (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for en-core-sci-md: filename=en_core_sci_md-0.2.5-cp36-none-any.whl size=79962017 sha256=b372926bdd019638759555a06926c9fb670ab96e1076100cfcc0ae8370c8ff8e\n",
+            "  Stored in directory: /root/.cache/pip/wheels/b8/ce/53/ed583ce748006061c2643822e610e36be61cb000d55e12180f\n",
+            "Successfully built en-core-sci-md\n",
+            "Requirement already satisfied: wikidataintegrator in /usr/local/lib/python3.6/dist-packages (0.7.4)\n",
+            "Requirement already satisfied: oauthlib in /usr/local/lib/python3.6/dist-packages (from wikidataintegrator) (3.1.0)\n",
+            "Requirement already satisfied: mwoauth in /usr/local/lib/python3.6/dist-packages (from wikidataintegrator) (0.3.7)\n",
+            "Requirement already satisfied: python-dateutil in /usr/local/lib/python3.6/dist-packages (from wikidataintegrator) (2.8.1)\n",
+            "Requirement already satisfied: tqdm in /usr/local/lib/python3.6/dist-packages (from wikidataintegrator) (4.41.1)\n",
+            "Requirement already satisfied: backoff in /usr/local/lib/python3.6/dist-packages (from wikidataintegrator) (1.10.0)\n",
+            "Requirement already satisfied: pyshex in /usr/local/lib/python3.6/dist-packages (from wikidataintegrator) (0.7.14)\n",
+            "Requirement already satisfied: jsonasobj in /usr/local/lib/python3.6/dist-packages (from wikidataintegrator) (1.2.1)\n",
+            "Requirement already satisfied: shexer in /usr/local/lib/python3.6/dist-packages (from wikidataintegrator) (0.0.8)\n",
+            "Requirement already satisfied: simplejson in /usr/local/lib/python3.6/dist-packages (from wikidataintegrator) (3.17.2)\n",
+            "Requirement already satisfied: ShExJSG in /usr/local/lib/python3.6/dist-packages (from wikidataintegrator) (0.7.0)\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.6/dist-packages (from wikidataintegrator) (1.0.5)\n",
+            "Requirement already satisfied: sparql-slurper in /usr/local/lib/python3.6/dist-packages (from wikidataintegrator) (0.3.4)\n",
+            "Requirement already satisfied: requests in /usr/local/lib/python3.6/dist-packages (from wikidataintegrator) (2.23.0)\n",
+            "Requirement already satisfied: six in /usr/local/lib/python3.6/dist-packages (from mwoauth->wikidataintegrator) (1.15.0)\n",
+            "Requirement already satisfied: requests-oauthlib in /usr/local/lib/python3.6/dist-packages (from mwoauth->wikidataintegrator) (1.3.0)\n",
+            "Requirement already satisfied: PyJWT<2.0.0,>=1.0.1 in /usr/local/lib/python3.6/dist-packages (from mwoauth->wikidataintegrator) (1.7.1)\n",
+            "Requirement already satisfied: urllib3 in /usr/local/lib/python3.6/dist-packages (from pyshex->wikidataintegrator) (1.24.3)\n",
+            "Requirement already satisfied: rdflib-jsonld>=0.4.0 in /usr/local/lib/python3.6/dist-packages (from pyshex->wikidataintegrator) (0.5.0)\n",
+            "Requirement already satisfied: cfgraph>=0.2.1 in /usr/local/lib/python3.6/dist-packages (from pyshex->wikidataintegrator) (0.2.1)\n",
+            "Requirement already satisfied: pyshexc>=0.5.4 in /usr/local/lib/python3.6/dist-packages (from pyshex->wikidataintegrator) (0.7.0)\n",
+            "Requirement already satisfied: rdflib>=4.2.2 in /usr/local/lib/python3.6/dist-packages (from pyshex->wikidataintegrator) (5.0.0)\n",
+            "Requirement already satisfied: sparqlwrapper in /usr/local/lib/python3.6/dist-packages (from pyshex->wikidataintegrator) (1.8.5)\n",
+            "Requirement already satisfied: Flask-Cors in /usr/local/lib/python3.6/dist-packages (from shexer->wikidataintegrator) (3.0.9)\n",
+            "Requirement already satisfied: Flask in /usr/local/lib/python3.6/dist-packages (from shexer->wikidataintegrator) (1.1.2)\n",
+            "Requirement already satisfied: pyjsg~=0.10 in /usr/local/lib/python3.6/dist-packages (from ShExJSG->wikidataintegrator) (0.10.0)\n",
+            "Requirement already satisfied: numpy>=1.13.3 in /usr/local/lib/python3.6/dist-packages (from pandas->wikidataintegrator) (1.18.5)\n",
+            "Requirement already satisfied: pytz>=2017.2 in /usr/local/lib/python3.6/dist-packages (from pandas->wikidataintegrator) (2018.9)\n",
+            "Requirement already satisfied: pbr in /usr/local/lib/python3.6/dist-packages (from sparql-slurper->wikidataintegrator) (5.5.0)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.6/dist-packages (from requests->wikidataintegrator) (2020.6.20)\n",
+            "Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.6/dist-packages (from requests->wikidataintegrator) (3.0.4)\n",
+            "Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.6/dist-packages (from requests->wikidataintegrator) (2.10)\n",
+            "Requirement already satisfied: antlr4-python3-runtime>=4.7 in /usr/local/lib/python3.6/dist-packages (from pyshexc>=0.5.4->pyshex->wikidataintegrator) (4.8)\n",
+            "Requirement already satisfied: isodate in /usr/local/lib/python3.6/dist-packages (from rdflib>=4.2.2->pyshex->wikidataintegrator) (0.6.0)\n",
+            "Requirement already satisfied: pyparsing in /usr/local/lib/python3.6/dist-packages (from rdflib>=4.2.2->pyshex->wikidataintegrator) (2.4.7)\n",
+            "Requirement already satisfied: Werkzeug>=0.15 in /usr/local/lib/python3.6/dist-packages (from Flask->shexer->wikidataintegrator) (1.0.1)\n",
+            "Requirement already satisfied: Jinja2>=2.10.1 in /usr/local/lib/python3.6/dist-packages (from Flask->shexer->wikidataintegrator) (2.11.2)\n",
+            "Requirement already satisfied: itsdangerous>=0.24 in /usr/local/lib/python3.6/dist-packages (from Flask->shexer->wikidataintegrator) (1.1.0)\n",
+            "Requirement already satisfied: click>=5.1 in /usr/local/lib/python3.6/dist-packages (from Flask->shexer->wikidataintegrator) (7.1.2)\n",
+            "Requirement already satisfied: MarkupSafe>=0.23 in /usr/local/lib/python3.6/dist-packages (from Jinja2>=2.10.1->Flask->shexer->wikidataintegrator) (1.1.1)\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "3xR9dKnWZBAO",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "import scispacy\n",
+        "import spacy\n",
+        "import pandas as pd\n",
+        "from wikidataintegrator import wdi_core\n",
+        "from scispacy.abbreviation import AbbreviationDetector\n",
+        "from scispacy.linking import EntityLinker\n",
+        "from functools import lru_cache"
+      ],
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "5yG2Qz05ZuTj",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "import en_core_sci_md\n",
+        "nlp = en_core_sci_md.load()"
+      ],
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "RS_YKN4vetXI",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 106
+        },
+        "outputId": "61e705d3-934d-474d-acb1-2880cc96aab6"
+      },
+      "source": [
+        "abbreviation_pipe = AbbreviationDetector(nlp)\n",
+        "nlp.add_pipe(abbreviation_pipe)\n",
+        "linker = EntityLinker(resolve_abbreviations=True, name=\"umls\")\n",
+        "nlp.add_pipe(linker)"
+      ],
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.6/dist-packages/sklearn/base.py:318: UserWarning: Trying to unpickle estimator TfidfTransformer from version 0.20.3 when using version 0.22.2.post1. This might lead to breaking code or invalid results. Use at your own risk.\n",
+            "  UserWarning)\n",
+            "/usr/local/lib/python3.6/dist-packages/sklearn/base.py:318: UserWarning: Trying to unpickle estimator TfidfVectorizer from version 0.20.3 when using version 0.22.2.post1. This might lead to breaking code or invalid results. Use at your own risk.\n",
+            "  UserWarning)\n"
+          ],
+          "name": "stderr"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "7oFnYiRygZNo",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Function by github.com/lubianat with some slight alterations by me\n",
+        "@lru_cache(maxsize=None)\n",
+        "def get_wikidata_item(wikidata_property, value):\n",
+        "    query_result = wdi_core.WDItemEngine.execute_sparql_query(\n",
+        "        f'SELECT distinct ?item WHERE {{ ?item wdt:{wikidata_property} \"{value}\" }}'\n",
+        "    )\n",
+        "    try:\n",
+        "        match = query_result[\"results\"][\"bindings\"][0]\n",
+        "    except:\n",
+        "        return None\n",
+        "    qid = match[\"item\"][\"value\"]\n",
+        "\n",
+        "    qid = qid.split(\"/\")[4]\n",
+        "    return qid"
+      ],
+      "execution_count": 5,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "SXzHNaoOnajc",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "def get_wdt_items_from_umls_entities(doc):\n",
+        "\n",
+        "  identified = []\n",
+        "  for ent in doc.ents:\n",
+        "      try:\n",
+        "        best_id = ent._.kb_ents[0][0]\n",
+        "      except IndexError:\n",
+        "        best_id = None\n",
+        "      identified.append([ent.text, ent.start_char, ent.end_char, best_id])\n",
+        "\n",
+        "  entity_df = pd.DataFrame.from_records(identified, \n",
+        "                                        columns=['label', 'start_pos', 'end_pos', 'umls_id'])\n",
+        "  \n",
+        "  entity_df['qid'] = entity_df['umls_id'].apply(lambda x: get_wikidata_item(\"P2892\", x))\n",
+        "\n",
+        "  return entity_df"
+      ],
+      "execution_count": 6,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "yrZ4EdWuoCq3",
+        "colab_type": "text"
+      },
+      "source": [
+        "### Testing out"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "MHXGNR-UeRHf",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "text = \"\"\"\n",
+        "Spinal and bulbar muscular atrophy (SBMA) is an\n",
+        "inherited motor neuron disease caused by the expansion\n",
+        "of a polyglutamine tract within the androgen receptor (AR).\n",
+        "SBMA can be caused by this easily.\n",
+        "\"\"\"\n",
+        "\n",
+        "doc = nlp(text)"
+      ],
+      "execution_count": 7,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "CQx9w-Q-mZNc",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 363
+        },
+        "outputId": "28e61d93-8d31-47ee-f3d3-b9adf8ef78ea"
+      },
+      "source": [
+        "get_wdt_items_from_umls_entities(doc)"
+      ],
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>label</th>\n",
+              "      <th>start_pos</th>\n",
+              "      <th>end_pos</th>\n",
+              "      <th>umls_id</th>\n",
+              "      <th>qid</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Spinal</td>\n",
+              "      <td>1</td>\n",
+              "      <td>7</td>\n",
+              "      <td>C0521329</td>\n",
+              "      <td>None</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>bulbar muscular atrophy</td>\n",
+              "      <td>12</td>\n",
+              "      <td>35</td>\n",
+              "      <td>C1839259</td>\n",
+              "      <td>Q1995327</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>SBMA</td>\n",
+              "      <td>37</td>\n",
+              "      <td>41</td>\n",
+              "      <td>C1839259</td>\n",
+              "      <td>Q1995327</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>inherited</td>\n",
+              "      <td>49</td>\n",
+              "      <td>58</td>\n",
+              "      <td>C0439660</td>\n",
+              "      <td>None</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>motor neuron disease</td>\n",
+              "      <td>59</td>\n",
+              "      <td>79</td>\n",
+              "      <td>C0085084</td>\n",
+              "      <td>Q3221083</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>5</th>\n",
+              "      <td>expansion</td>\n",
+              "      <td>94</td>\n",
+              "      <td>103</td>\n",
+              "      <td>C0007595</td>\n",
+              "      <td>None</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>6</th>\n",
+              "      <td>polyglutamine tract</td>\n",
+              "      <td>109</td>\n",
+              "      <td>128</td>\n",
+              "      <td>C0032500</td>\n",
+              "      <td>None</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>7</th>\n",
+              "      <td>androgen receptor</td>\n",
+              "      <td>140</td>\n",
+              "      <td>157</td>\n",
+              "      <td>C0034786</td>\n",
+              "      <td>None</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>8</th>\n",
+              "      <td>AR</td>\n",
+              "      <td>159</td>\n",
+              "      <td>161</td>\n",
+              "      <td>C0034786</td>\n",
+              "      <td>None</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>9</th>\n",
+              "      <td>SBMA</td>\n",
+              "      <td>164</td>\n",
+              "      <td>168</td>\n",
+              "      <td>C1839259</td>\n",
+              "      <td>Q1995327</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                     label  start_pos  end_pos   umls_id       qid\n",
+              "0                   Spinal          1        7  C0521329      None\n",
+              "1  bulbar muscular atrophy         12       35  C1839259  Q1995327\n",
+              "2                     SBMA         37       41  C1839259  Q1995327\n",
+              "3                inherited         49       58  C0439660      None\n",
+              "4     motor neuron disease         59       79  C0085084  Q3221083\n",
+              "5                expansion         94      103  C0007595      None\n",
+              "6      polyglutamine tract        109      128  C0032500      None\n",
+              "7        androgen receptor        140      157  C0034786      None\n",
+              "8                       AR        159      161  C0034786      None\n",
+              "9                     SBMA        164      168  C1839259  Q1995327"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 8
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
#21 suggests translating the UMLS IDs recognized by SciSpacy to Wikidata QIDs, coincidentally I was thinking the same thing and sketched a simple prototype to do just that.

The prototype is intended to run inside google colab, or at the very least a machine more powerful than the one I have, since it takes a lot of RAM to load the entity linking model. 